### PR TITLE
ip-address lib does not have class

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -80,7 +80,7 @@ X11Proxy.prototype.newClient = function (socket) {
       );
   } else {
     idBuf.writeUInt8(6, 18);
-    idBuf = (new ip.v6.Address(socket.remoteAddress)).parsedAddress
+    idBuf = (new ip.Address6(socket.remoteAddress)).parsedAddress
       .reduce(
           function (o, v, i) {
             o.writeUInt16BE(v, i * 2);

--- a/src/x_protocol.js
+++ b/src/x_protocol.js
@@ -1,7 +1,7 @@
 import { GCVField, WinVField, WinConfigureField } from './common';
 import * as x_types from './x_types';
 import EndianBuffer from './endianbuffer';
-import { v6 } from 'ip-address';
+import { Address6 } from 'ip-address';
 
 export class XProtocolServer  {
   constructor(socket, onClose) {
@@ -105,7 +105,7 @@ export class XProtocolClient  {
         .join('.');
     } else {
       this.host_type = 'InternetV6';
-      this.host = (new v6.Address(
+      this.host = (new Address6(
           Array.apply(null, new Array(8))
             .map(function (v, i) {
               return this.idBuf.readUInt16(i * 2)


### PR DESCRIPTION
 * ip-address - https://www.npmjs.com/package/ip-address did not have vs.Adress class.
 * modified so that it used Address6.
 * Tested with xeyes.

Awesome project btw.